### PR TITLE
Alew/improved test output

### DIFF
--- a/test/processData.test.js
+++ b/test/processData.test.js
@@ -63,7 +63,6 @@ describe("Process Data", () => {
   });
   it("should throw error on empty file contents", done => {
     const filename = "test-output-5.txt";
-    files.push(filename);
     const inputFile = "test/fixtures/emptyInput.txt";
     processData(inputFile, filename, msg => {
       assert.equal(msg, `Empty file ${inputFile}`);

--- a/test/processData.test.js
+++ b/test/processData.test.js
@@ -23,9 +23,9 @@ describe("Process Data", () => {
       null,
       null,
       () => {
-        const outputBuff = fs.readFileSync("test/fixtures/formattedOutput.txt");
-        const genOutputBuff = fs.readFileSync(filename);
-        assert.equal(outputBuff.equals(genOutputBuff), true);
+        const output = fs.readFileSync("test/fixtures/formattedOutput.txt", "utf-8");
+        const genOutput = fs.readFileSync(filename, "utf-8");
+        assert.equal(output, genOutput);
         done();
       }
     );
@@ -39,9 +39,9 @@ describe("Process Data", () => {
       null,
       null,
       () => {
-        const outputBuff = fs.readFileSync("test/fixtures/formattedOutput.txt");
-        const genOutputBuff = fs.readFileSync(filename);
-        assert.equal(outputBuff.equals(genOutputBuff), true);
+        const output = fs.readFileSync("test/fixtures/formattedOutput.txt", "utf-8");
+        const genOutput = fs.readFileSync(filename, "utf-8");
+        assert.equal(output, genOutput);
         done();
       }
     );
@@ -79,11 +79,12 @@ describe("Process Data", () => {
       null,
       null,
       () => {
-        const outputBuff = fs.readFileSync(
-          "test/fixtures/ignoreMatchday4Output.txt"
+        const output = fs.readFileSync(
+          "test/fixtures/ignoreMatchday4Output.txt",
+          "utf-8",
         );
-        const genOutputBuff = fs.readFileSync(filename);
-        assert.equal(outputBuff.equals(genOutputBuff), true);
+        const genOutput = fs.readFileSync(filename, "utf-8");
+        assert.equal(output, genOutput);
         done();
       }
     );


### PR DESCRIPTION
changes test output from 

```bash
-expected
+actual
-true
+false
```

to a string output diff.

Also reverts the red herring failing test